### PR TITLE
added dollyIn() / dollyOut() functions in OrbitControls

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -46,7 +46,11 @@ export class OrbitControls {
     keys: { LEFT: string; UP: string; RIGHT: string; BOTTOM: string };
     mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE };
     touches: { ONE: TOUCH; TWO: TOUCH };
+    
+    dollyIn(dollyScale: number): void;
 
+    dollyOut(dollyScale: number): void;
+    
     update(): boolean;
 
     listenToKeyEvents(domElement: HTMLElement): void;


### PR DESCRIPTION

### Why

To programatically change zoom (eg with a zoom slider widget)

### What

added dollyIn() and dollyOut() types.

### Checklist


-   [ ] Added myself to contributors table
-   [x] Ready to be merged

